### PR TITLE
Home dashboard feature flag integration

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -83,12 +83,13 @@ export const routes: Routes = [
   {
     path: ':entity/:space',
     resolve: {
-      context: ContextResolver,
-      featureFlagConfig: FeatureFlagResolver
+      context: ContextResolver
+ //     featureFlagConfig: FeatureFlagResolver
     },
     loadChildren: './space/analyze/analyze.module#AnalyzeModule',
     data: {
       title: 'Analyze'
+      // featureName: 'newHomeDashboard'
     }
   },
 

--- a/src/app/dashboard-widgets/recent-pipelines-widget/recent-pipelines-widget.component.html
+++ b/src/app/dashboard-widgets/recent-pipelines-widget/recent-pipelines-widget.component.html
@@ -1,4 +1,4 @@
-<f8-feature-toggle featureName="newHomeDashboard">
+<f8-feature-toggle featureName="newHomeDashboard" restricted="dev">
   <div id="recent-apps-card" class="card-pf f8-card-lg" user-level>
     <div class="card-pf-heading f8-card-heading">
       <h2 class="card-pf-title">

--- a/src/app/dashboard-widgets/recent-pipelines-widget/recent-pipelines-widget.component.html
+++ b/src/app/dashboard-widgets/recent-pipelines-widget/recent-pipelines-widget.component.html
@@ -1,5 +1,5 @@
-<div *ngIf="newHomeDashboardEnabled && developmentEnabled"> <!-- set 'developmentEnabled' to false in component.ts to hide -->
-  <div id="recent-apps-card" class="card-pf f8-card-lg">
+<f8-feature-toggle featureName="newHomeDashboard">
+  <div id="recent-apps-card" class="card-pf f8-card-lg" user-level>
     <div class="card-pf-heading f8-card-heading">
       <h2 class="card-pf-title">
         Recent Workspaces
@@ -35,9 +35,7 @@
       </div> -->
     </div>
   </div>
-</div>
-<div *ngIf="!newHomeDashboardEnabled">
-  <div id="recent-pipelines-card" class="pipelines-widget card-pf f8-card">
+  <div id="recent-pipelines-card" class="pipelines-widget card-pf f8-card" default-level>
     <div class="card-pf-heading f8-card-heading">
       <h2 class="card-pf-title">
         Recent Active Pipelines
@@ -77,4 +75,5 @@
       </ul>
     </div>
   </div>
-</div>
+
+</f8-feature-toggle>

--- a/src/app/dashboard-widgets/recent-pipelines-widget/recent-pipelines-widget.component.ts
+++ b/src/app/dashboard-widgets/recent-pipelines-widget/recent-pipelines-widget.component.ts
@@ -20,7 +20,7 @@ export class RecentPipelinesWidgetComponent implements OnInit {
   contextPath: Observable<string>;
   buildConfigs: ConnectableObservable<BuildConfigs>;
   buildConfigsCount: Observable<number>;
-  newHomeDashboardEnabled: boolean = false;
+  newHomeDashboardEnabled: boolean = true;
   developmentEnabled: boolean = false; // set to false to hide for prod - set to true for local development
   subscriptions: Subscription[] = [];
 

--- a/src/app/dashboard-widgets/recent-pipelines-widget/recent-pipelines-widget.module.ts
+++ b/src/app/dashboard-widgets/recent-pipelines-widget/recent-pipelines-widget.module.ts
@@ -5,11 +5,12 @@ import { RouterModule } from '@angular/router';
 
 import { MomentModule } from 'angular2-moment';
 
+import { FeatureFlagModule } from '../../feature-flag/feature-flag.module';
 import { RecentPipelinesWidgetComponent } from './recent-pipelines-widget.component';
 
 
 @NgModule({
-  imports: [CommonModule, FormsModule, RouterModule, MomentModule ],
+  imports: [CommonModule, FormsModule, RouterModule, MomentModule, FeatureFlagModule ],
   declarations: [RecentPipelinesWidgetComponent],
   exports: [RecentPipelinesWidgetComponent]
 })

--- a/src/app/feature-flag/feature-wrapper/feature-toggle.component.spec.ts
+++ b/src/app/feature-flag/feature-wrapper/feature-toggle.component.spec.ts
@@ -24,7 +24,7 @@ describe('FeatureToggleComponent', () => {
 
   @Component({
     selector: `host-component`,
-    template: `<f8-feature-toggle featureName="Planner"><div>My content here</div></f8-feature-toggle>`
+    template: `<f8-feature-toggle featureName="Planner"><div user-level>My content here</div></f8-feature-toggle>`
   })
   class TestHostComponent {
   }

--- a/src/app/feature-flag/feature-wrapper/feature-toggle.component.ts
+++ b/src/app/feature-flag/feature-wrapper/feature-toggle.component.ts
@@ -7,7 +7,7 @@ import { Feature, FeatureTogglesService } from '../service/feature-toggles.servi
 
 @Component({
   selector: 'f8-feature-toggle',
-  template: `<ng-content *ngIf="isEnabled"></ng-content>`
+  template: `<ng-content *ngIf="isEnabled" select="[user-level]"></ng-content><ng-content *ngIf="!isEnabled" select="[default-level]"></ng-content>`
 })
 export class FeatureToggleComponent implements OnInit {
   @Input() featureName: string;

--- a/src/app/feature-flag/feature-wrapper/feature-toggle.component.ts
+++ b/src/app/feature-flag/feature-wrapper/feature-toggle.component.ts
@@ -11,7 +11,9 @@ import { Feature, FeatureTogglesService } from '../service/feature-toggles.servi
 })
 export class FeatureToggleComponent implements OnInit {
   @Input() featureName: string;
+  @Input() restricted = 'prod';
   isEnabled = false;
+  currentUrl = window.location.href;
 
   constructor(private featureService: FeatureTogglesService) {}
 
@@ -21,7 +23,12 @@ export class FeatureToggleComponent implements OnInit {
     }
 
     this.featureService.getFeature(this.featureName).subscribe((f: Feature) => {
-        this.isEnabled = f.attributes.enabled && f.attributes['user-enabled'];
+        let localHost = this.currentUrl.indexOf('localhost') > -1;
+        if (this.restricted.toLowerCase() === 'dev') {
+          this.isEnabled = f.attributes.enabled && f.attributes['user-enabled'] && localHost;
+        } else {
+          this.isEnabled = f.attributes.enabled && f.attributes['user-enabled'];
+        }
       },
       err => {
         this.isEnabled = false;


### PR DESCRIPTION
@mindreeper2420 with @xcoulon we came up with a proposal like that:
- `newHomeDashboard` is marked `internal`, therefore wrapper (f8-feature-toggle component) will display the `user-level` section if user-enabled is true otherwise it will display the `default-level`
- to deal with the localhost I've added an attribute `restricted` with default value. Once ready to be shown on prod-preview, just remove `restricted=dev` 

This is a proposal that will need polishing on edge cases but @mindreeper2420 does it fit your needs?